### PR TITLE
Updated to support multiple /home directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It safely steps through the file structure only in a particular user, and sets f
 
 It is safe to run, and I would run it in a heart-beat as a general 'fix my errors' fix.
 
+For those running multiple attached volumes on their servers, such as multiple home directories with cPanel (eg., /home, /home2, /home3, etc), [Will Ashworth](http://www.williamashworth.com) has updated the script to figure out the user's true home directory, and the script will repair permissions as needed for that user(s). This is a rather new change, so please let us know in the comments if you experience any weird issues. However, we've tested this and it does appear to be working fine (hasn't broken anything yet!).
+
 Note: This is inteded for non-DSO servers (ex: FastCGI, suPHP, etc...). You CAN run this on a DSO box, but just know that things such as Wordpress uploads won't work. You'll have to manually set some folders to be owned by the user "nobody".
 
 ## Instructions

--- a/fixperms.sh
+++ b/fixperms.sh
@@ -3,6 +3,7 @@
 # Date: Jan 26th 2012
 # Author: Colin R.
 # Revisions: Jacob "Boom Shadow" Tirey (boomshadow.net)
+# Revisions: Will Ashworth (williamashworth.com || ashworthconsulting.com)
 # Fixperms script for ServInt
 #
 # https://github.com/PeachFlame/cPanel-fixperms
@@ -69,6 +70,10 @@ fixperms () {
     helptext
   #Else, start doing work
   else
+
+    #Get the account's homedir
+    HOMEDIR=$(egrep "^${account}:" /etc/passwd | cut -d: -f6)
+
     tput bold
     tput setaf 4
     echo "Fixing perms for $account:"
@@ -77,20 +82,21 @@ fixperms () {
     tput setaf 4
     echo "Fixing website files...."
     tput sgr0
+    
     #Fix individual files in public_html
-    find /home/$account/public_html -type d -exec chmod $verbose 755 {} \;
-    find /home/$account/public_html -type f | xargs -d$'\n' -r chmod $verbose 644
-    find /home/$account/public_html -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
-    chown $verbose -R $account:$account /home/$account/public_html/*
-    find /home/$account/* -name .htaccess -exec chown $verbose $account.$account {} \;
+    find $HOMEDIR/public_html -type d -exec chmod $verbose 755 {} \;
+    find $HOMEDIR/public_html -type f | xargs -d$'\n' -r chmod $verbose 644
+    find $HOMEDIR/public_html -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
+    chown $verbose -R $account:$account $HOMEDIR/public_html/*
+    find $HOMEDIR/* -name .htaccess -exec chown $verbose $account.$account {} \;
 
     tput bold
     tput setaf 4
     echo "Fixing public_html...."
     tput sgr0
     #Fix perms of public_html itself
-    chown $verbose $account:nobody /home/$account/public_html
-    chmod $verbose 750 /home/$account/public_html
+    chown $verbose $account:nobody $HOMEDIR/public_html
+    chmod $verbose 750 $HOMEDIR/public_html
 
     #Fix subdomains that lie outside of public_html
     tput setaf 3
@@ -100,23 +106,23 @@ fixperms () {
     echo "Fixing any domains with a document root outside of public_html...."
     for SUBDOMAIN in $(grep -i document /var/cpanel/userdata/$account/* | awk '{print $2}' | grep home | grep -v public_html)
     do
-	tput bold
-	tput setaf 4
-	echo "Fixing sub/addon domain document root $SUBDOMAIN...."
-	tput sgr0
-	find $SUBDOMAIN -type d -exec chmod $verbose 755 {} \;
-	find $SUBDOMAIN -type f | xargs -d$'\n' -r chmod $verbose 644
-  	find $SUBDOMAIN -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
+  tput bold
+  tput setaf 4
+  echo "Fixing sub/addon domain document root $SUBDOMAIN...."
+  tput sgr0
+  find $SUBDOMAIN -type d -exec chmod $verbose 755 {} \;
+  find $SUBDOMAIN -type f | xargs -d$'\n' -r chmod $verbose 644
+    find $SUBDOMAIN -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
     chown $verbose -R $account:$account $SUBDOMAIN
     find $SUBDOMAIN -name .htaccess -exec chown $verbose $account.$account {} \;
     done
 
-	#Finished
+  #Finished
     tput bold
     tput setaf 3
     echo "Finished!"
-	echo "------------------------"
-	printf "\n\n"
+  echo "------------------------"
+  printf "\n\n"
     tput sgr0
   fi
 
@@ -128,7 +134,7 @@ all () {
     cd /var/cpanel/users
     for user in *
     do
-	fixperms $user
+  fixperms $user
     done
 }
 
@@ -136,33 +142,33 @@ all () {
 case "$1" in
 
     -h) helptext
-	;;
+  ;;
     --help) helptext
-	    ;;
+      ;;
     -v) verbose="-v"
 
-	case "$2" in
-
-		-all) all
-		       ;;
-		--account) fixperms "$3"
-			   ;;
-		-a) fixperms "$3"
-		    ;;
-		*) tput bold
-     		   tput setaf 1
-		   echo "Invalid Option!"
-		   helptext
-		   ;;
-	esac
-	;;
+  case "$2" in
 
     -all) all
-	  ;;
+           ;;
+    --account) fixperms "$3"
+         ;;
+    -a) fixperms "$3"
+        ;;
+    *) tput bold
+           tput setaf 1
+       echo "Invalid Option!"
+       helptext
+       ;;
+  esac
+  ;;
+
+    -all) all
+    ;;
     --account) fixperms "$2"
-      	 	;;
+          ;;
     -a) fixperms "$2"
-	;;
+  ;;
     *)
        tput bold
        tput setaf 1


### PR DESCRIPTION
This version is exactly the same as Boom Shadow’s version, however, I’ve modified it to support additional /home directories so that permissions extend beyond just the default /home directory.

In our servers, we often have a surplus of RAM and CPU due to governors that we’ve put in place to protect and “keep fair” the resources on our servers, but we eventually eat up disk space before we reach a point of maxing out RAM or CPU. So we use cPanel’s ability to create additional home directories (ie., /home, /home2, /home3), each of them on their own attached storage volume.

You’ll run the script the same way, but this version of the script will automatically find the user’s “true” home directory. Once it finds that, it will continue as this script has always operated…fixing the permissions.
- finds the user's true home directory
- runs all the same great commands on that directory
- run the script as you normally would, nothing changes

Signed-off-by: Will Ashworth will@ashworthconsulting.com
