### PR TITLE
Update fixperms.sh

### DIFF
--- a/fixperms.sh
+++ b/fixperms.sh
@@ -69,7 +69,9 @@ fixperms () {
     find $HOMEDIR/public_html -type d -exec chmod $verbose 755 {} \;
     find $HOMEDIR/public_html -type f | xargs -d$'\n' -r chmod $verbose 644
     find $HOMEDIR/public_html -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
-    chown $verbose -R $account:$account $HOMEDIR/public_html/*
+    # Hidden files support: https://serverfault.com/a/156481
+    # fix hidden files and folders like .well-known/ with root or other user perms
+    chown $verbose -R $account:$account $HOMEDIR/public_html/.[^.]*
     find $HOMEDIR/* -name .htaccess -exec chown $verbose $account.$account {} \;
 
     tput bold


### PR DESCRIPTION
This fixes and edge case where hidden files or folders are ignored. Seen a few accounts i ran this on cPanel wise not fixed entirely and fixed it in my personal cPanel/CyberPanel copy. I'm submitting this upstream so it saves some people a real headache later on as a courtesy.

Reference:
https://github.com/whattheserver/cyberpanel-fixperms/issues/1