### PR TITLE
Add non-hidden-files chown within public_html

### DIFF
--- a/fixperms.sh
+++ b/fixperms.sh
@@ -71,8 +71,9 @@ fixperms () {
         find $HOMEDIR/public_html -type d -exec chmod $verbose 755 {} \;
         find $HOMEDIR/public_html -type f | xargs -d$'\n' -r chmod $verbose 644
         find $HOMEDIR/public_html -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
-        # Hidden files support - ref: https://serverfault.com/a/156481
+        # Regular and Hidden files support - ref: https://serverfault.com/a/156481
         # Fix hidden files and folders like .well-known/ with root or other user perms
+        chown $verbose -R $account:$account $HOMEDIR/public_html/*
         chown $verbose -R $account:$account $HOMEDIR/public_html/.[^.]*
         find $HOMEDIR/* -name .htaccess -exec chown $verbose $account.$account {} \;
 


### PR DESCRIPTION
fixperms script should correct permissions issues within public_html in the event files are NOT hidden. 

Currently it targets . files, which are normally excluded when running a regular /dir/example/* invocation of chown.