### PR TITLE
Add Backup Option (-b) & chown public_html files (not just dotfiles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ wget https://raw.githubusercontent.com/PeachFlame/cPanel-fixperms/master/fixperm
 chmod +x fixperms.sh
 ```
 
-Then, run it (with ROOT permissions) while using the 'a' flag to specify a particular cPanel user:
+Then, run it (with **root** permissions) while using the 'a' flag to specify a particular cPanel user:
 ```bash
 sudo sh ./fixperms.sh -a USER-NAME
 ```
@@ -59,10 +59,11 @@ I host numerous websites for friends and family, who will routinely make mistake
 
 ```bash
 sudo mv fixperms.sh /usr/bin/fixperms
+sudo chmod +x /usr/bin/fixperms
 ```
 
 ## History
-Now that `fixperms` is in Github, all contributors will have proper credit. However, before the move to Github, there were a 2 individuals that were crucial to the scripts existence:
+Now that `fixperms` is in GitHub, all contributors will have proper credit. However, before the move to GitHub, there were a 2 individuals that were crucial to the scripts existence:
 
 - Dean Freeman
 - Colin R.

--- a/fixperms.sh
+++ b/fixperms.sh
@@ -71,8 +71,9 @@ fixperms () {
         find $HOMEDIR/public_html -type d -exec chmod $verbose 755 {} \;
         find $HOMEDIR/public_html -type f | xargs -d$'\n' -r chmod $verbose 644
         find $HOMEDIR/public_html -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
-        # Hidden files support - ref: https://serverfault.com/a/156481
+        # Regular and Hidden files support - ref: https://serverfault.com/a/156481
         # Fix hidden files and folders like .well-known/ with root or other user perms
+        chown $verbose -R $account:$account $HOMEDIR/public_html/*
         chown $verbose -R $account:$account $HOMEDIR/public_html/.[^.]*
         find $HOMEDIR/* -name .htaccess -exec chown $verbose $account.$account {} \;
 

--- a/fixperms.sh
+++ b/fixperms.sh
@@ -14,13 +14,13 @@ helptext () {
     tput setaf 2
     echo "Fix Permissions (fixperms) Script help:"
     echo "Sets file/directory permissions to match suPHP and FastCGI schemes"
-    echo "USAGE: fixperms [options] [scope]"
+    echo "USAGE: fixperms [option] [scope]"
     echo "-------"
     echo "Scope:"
     echo "--account or -a: Specify a cPanel account"
     echo "-all: Run fixperms on all cPanel accounts"
     echo "Options:"
-    echo "-b: Backup perms (declare before -a/-all)"
+    echo "-b: Backup firstly"
     echo "-v: Verbose output"
     echo "-h or --help: Print this screen and exit"
     tput sgr0
@@ -85,7 +85,7 @@ fixperms () {
         find $HOMEDIR/public_html -type d -exec chmod $verbose 755 {} \;
         find $HOMEDIR/public_html -type f | xargs -d$'\n' -r chmod $verbose 644
         find $HOMEDIR/public_html -name '*.cgi' -o -name '*.pl' | xargs -r chmod $verbose 755
-        # Regular and Hidden files support - ref: https://serverfault.com/a/156481
+        # Regular and Hidden files support - hidden ref: https://serverfault.com/a/156481
         # Fix hidden files and folders like .well-known/ with root or other user perms
         chown $verbose -R $account:$account $HOMEDIR/public_html/*
         chown $verbose -R $account:$account $HOMEDIR/public_html/.[^.]*


### PR DESCRIPTION
This PR does two things @boomshadow 

1. fixperms will now correct permissions issues within public_html in the event files are NOT hidden.

Before it targeted just dotfiles, which are normally excluded when running a regular /dir/example/* invocation of chown.

2. Adds a -b option to backup existing permissions BEFORE running through the fixperms work.

This resolves #10 and works for single account usage as well as all accounts.

(-v and -b simultaneously isn't functional - haven't delved into cases)